### PR TITLE
Adding support for soft_alldifferent in MiniZinc

### DIFF
--- a/src/main/java/org/jacop/fz/Constraints.java
+++ b/src/main/java/org/jacop/fz/Constraints.java
@@ -1841,10 +1841,10 @@ public class Constraints implements ParserTreeConstants {
    		    pose( new Geost(objects, constraints, shapes) );
 		}
 		else
-		    System.err.println("%% ERRO1R: Constraint "+p+" not supported.");
+		    System.err.println("%% ERROR: Constraint "+p+" not supported.");
 	    // >>========== JaCoP constraints ==================
 	    else
-		System.err.println("%% ERRO1R: Constraint "+p+" not supported.");
+		System.err.println("%% ERROR: Constraint "+p+" not supported.");
 	}
     }
 

--- a/src/main/java/org/jacop/fz/Constraints.java
+++ b/src/main/java/org/jacop/fz/Constraints.java
@@ -1201,6 +1201,17 @@ public class Constraints implements ParserTreeConstants {
 			//			System.out.println("Alldiff imposed");
 		    }
 		}
+		else if (p.startsWith("softalldiff", 6)) { // just really a synonym for all different, isn't it ? 
+		    IntVar[] x = getVarArray((SimpleNode)node.jjtGetChild(0));
+		    IntVar s = getVariable((ASTScalarFlatExpr)node.jjtGetChild(1));
+		    int useDecomp = getInt((ASTScalarFlatExpr)node.jjtGetChild(2));
+		    // 0 if false, 1 if true
+		    ViolationMeasure usedMeasure = (useDecomp == 0) ? ViolationMeasure.VARIABLE_BASED : ViolationMeasure.DECOMPOSITION_BASED ;
+		    
+		   	poseDC(new SoftAlldifferent(x, s, usedMeasure));
+			//			System.out.println("Alldiff imposed");
+		 
+		}
 		else if (p.startsWith("alldistinct", 6)) {
 		    IntVar[] v = getVarArray((SimpleNode)node.jjtGetChild(0));
 		    // we do not not pose Alldistinct directly because of possible inconsistency with its 
@@ -1830,10 +1841,10 @@ public class Constraints implements ParserTreeConstants {
    		    pose( new Geost(objects, constraints, shapes) );
 		}
 		else
-		    System.err.println("%% ERROR: Constraint "+p+" not supported.");
+		    System.err.println("%% ERRO1R: Constraint "+p+" not supported.");
 	    // >>========== JaCoP constraints ==================
 	    else
-		System.err.println("%% ERROR: Constraint "+p+" not supported.");
+		System.err.println("%% ERRO1R: Constraint "+p+" not supported.");
 	}
     }
 
@@ -3992,6 +4003,14 @@ public class Constraints implements ParserTreeConstants {
 	}
     }
 
+    void poseDC(DecomposedConstraint c) throws FailException {
+
+    	store.imposeDecompositionWithConsistency(c);
+    	
+    	if (debug)
+    	    System.out.println(c);
+    }
+    
     void pose(Constraint c) throws FailException {
 
 	store.imposeWithConsistency(c);	

--- a/src/main/minizinc/org/jacop/minizinc/soft_constraints/soft_all_different_int.mzn
+++ b/src/main/minizinc/org/jacop/minizinc/soft_constraints/soft_all_different_int.mzn
@@ -1,0 +1,10 @@
+%-----------------------------------------------------------------------------%
+% Constrains the array of objects 'x' to be all different with a tolerance 
+% defined by d.
+%-----------------------------------------------------------------------------%
+predicate soft_all_different_int(array[int] of var int: x, var int: d, bool: useDec) =
+	  jacop_softalldiff(x, d, useDec);
+
+%    = forall(i,j in index_set(x) where i < j) ( x[i] != x[j] );
+
+predicate jacop_softalldiff(array[int] of var int: x, var int: d, bool: useDec);


### PR DESCRIPTION
Hi,

I would like to propose very small additions to the FlatZinc interpreter to allow for soft globals, starting  with soft alldifferent (I want to give soft GCC a shot, later).

These additions would be part of [MiniBrass](http://isse-augsburg.github.io/constraint-relationships/), a library that adds soft constraint support to MiniZinc.

JaCoP would be the first solver that supports these soft globals in MiniZinc. I have tried it locally with a standard MiniZinc decomposition for solvers not supporting soft-alldifferent being present in MiniBrass.

A presentation showing the integration is attached [here](https://github.com/radsz/jacop/files/116093/soft-globals.pdf).

It would be awesome to have JaCoP on board!

Cheers,
Alex
