### PR TITLE
Remove unused logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -675,17 +675,6 @@ setup to run configuration. -->
 	  <artifactId>scala-xml_2.12</artifactId>
 	  <version>1.1.1</version>
 	</dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.24</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-            <version>1.7.24</version>
-        </dependency>
-
     </dependencies>
 
 </project>


### PR DESCRIPTION
Hello, I noticed that dependencies `slf4j-api` and `slf4j-log4j12` were added to the `pom` since the beginning of the project. However, these logging dependencies are not used, so they can be safely removed from the `pom`. This makes the project slimmer and its dependency tree more easy to maintain.