### PR TITLE
Improve MAVEN build Performance

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <aspectj.version>1.8.10</aspectj.version>
         <checkstyle.config.location>resources/checkstyle.xml</checkstyle.config.location>
+    	<closeTestReports>true</closeTestReports>
     </properties>
 
     <!-- In order to see logging output,
@@ -120,6 +121,7 @@ setup to run configuration. -->
                                 <exclude>**/MinizincBasedTestAbove1Hours.java</exclude>
                                 <exclude>**/MinizincBasedChosen.java</exclude>
                             </excludes>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
                         </configuration>
                     </plugin>
 
@@ -151,6 +153,7 @@ setup to run configuration. -->
                                 <exclude>**/MinizincBasedTestAbove1Hours.java</exclude>
                                 <exclude>**/MinizincBasedChosen.java</exclude>
                             </excludes>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
                         </configuration>
                     </plugin>
 
@@ -182,6 +185,7 @@ setup to run configuration. -->
                                 <exclude>**/MinizincBasedTestAbove1Hours.java</exclude>
                                 <exclude>**/MinizincBasedChosen.java</exclude>
                             </excludes>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
                         </configuration>
                     </plugin>
 
@@ -213,6 +217,7 @@ setup to run configuration. -->
                                 <exclude>**/MinizincBasedTestAbove1Hours.java</exclude>
                                 <exclude>**/MinizincBasedChosen.java</exclude>
                             </excludes>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -532,6 +537,7 @@ setup to run configuration. -->
                         <exclude>**/MinizincBasedTestAbove1Hours.java</exclude>
                         <exclude>**/MinizincBasedChosen.java</exclude>
                     </excludes>
+                	<disableXmlReport>${closeTestReports}</disableXmlReport>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION

That report generation takes time, slowing down the overall build. Reports are definitely useful, but do you need them every time you run the build. We can conditionally disable generating test reports by setting `<disableXmlReport>true<disableXmlReport>`. If you need to generate reports, just add `-DcloseTestReports=false` to the end of mvn build command.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
